### PR TITLE
Get the add-on working with ‘cfx run’.

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -1,14 +1,14 @@
-var require("sdk/tabs");
-var buttons = require('sdk/ui/button/action');
+var buttons = require("sdk/ui/button/action");
+var Request = require("sdk/request").Request;
 var tabs = require("sdk/tabs");
-var domain, reqest, response ;
+var URL = require("sdk/url").URL;
 
 var icons = {
   "inactive": {
     "16": "./icon-16.png",
     "32": "./icon-32.png",
     "64": "./icon-64.png"
-  }
+  },
   "active": {
     "16": "./icon-16.png",
     "32": "./icon-32.png",
@@ -17,37 +17,37 @@ var icons = {
 }
 
 
-
 var button = buttons.ActionButton({
   id: "contribute",
   label: "How to contribute!",
-    icon: icons.inactive,
-      onClick: dealWithIt;
+  icon: icons.inactive,
+  onClick: dealWithIt
 });
 
-functon dealWithIt() {
-    console.log(""); 
-
+function dealWithIt() {
+  console.log("");
 };
 
 function toggleIcon(state) {
-    if(state == true){
-      button.icon = icons.active;
-    }
+  if(state == true){
+    button.icon = icons.active;
+  }
 }
 
 
-tab.on('ready', function(tab){
-  req = require("sdk/request").Request({
-      url: new URL("/contribute.json", window.location),
-      onComplete: function(resp){
-      if(resp.status >= 200 && resp.status < 300 && resp.json != null){
+tabs.on("ready", function (tab) {
+  debugger;
+  var req = Request({
+    url: new URL("/contribute.json", tab.url),
+    onComplete: function (resp) {
+      if (resp.status >= 200 && resp.status < 300 && resp.json != null) {
         toggleIcon(true);
-        console.log(url + " - Contribute.json available!");
+        console.log(req.url + " - Contribute.json available!");
       } else {
         toggleIcon(false);
-        console.log(url + " - Contribute.json unavailable, humbug.");
-   });
+        console.log(req.url + " - Contribute.json unavailable, humbug.");
+      }
+      return;
+    }
+  }).get();
 });
-
-

--- a/package.json
+++ b/package.json
@@ -1,9 +1,10 @@
 {
-  "name": "Muditanist",
+  "name": "muditanist",
   "title": "Muditanist",
   "id": "jid1-oyNpUQcL3f9kyg",
   "description": "The Muditanist addon lights up when you're looking at a site that welcomes contributors.",
   "author": "Michael Hoye",
+  "contributors": ["Blake Winton <bwinton@latte.ca>"],
   "license": "MPL 2.0",
   "version": "0.1"
 }


### PR DESCRIPTION
You might want to log `tab.url` instead of `req.url`.  Your choice.
Also, I needed to type `cfx run -b /Applications/Local/Firefox.app` instead of `cfx run` because I like to store my Firefox in an odd place.
